### PR TITLE
Fixed recover password errors

### DIFF
--- a/src/main/kotlin/es/wokis/data/datasource/recover/RecoverLocalDataSource.kt
+++ b/src/main/kotlin/es/wokis/data/datasource/recover/RecoverLocalDataSource.kt
@@ -21,7 +21,7 @@ interface RecoverLocalDataSource {
 class RecoverLocalDataSourceImpl(private val recoverCollection: MongoCollection<RecoverDBO>) :
     RecoverLocalDataSource {
     override suspend fun getRecoverByToken(token: String): RecoverBO? =
-        recoverCollection.findOne(RecoverDBO::recoverToken.regex(token))?.toBO()
+        recoverCollection.findOne(RecoverDBO::recoverToken eq token)?.toBO()
 
     override suspend fun saveRecoverRequest(recover: RecoverBO): Boolean {
         return try {

--- a/src/main/kotlin/es/wokis/data/repository/recover/RecoverRepository.kt
+++ b/src/main/kotlin/es/wokis/data/repository/recover/RecoverRepository.kt
@@ -49,9 +49,6 @@ class RecoverRepositoryImpl(
     override suspend fun requestChangePass(email: String): AcknowledgeBO {
         val user = userRepository.getUserByEmail(email)
         user?.let {
-            if (user.emailVerified) {
-                throw IllegalStateException()
-            }
             emailService.sendRecoverPass(user)?.also {
                 return saveRequestChangePass(it)
             } ?: throw IllegalStateException()

--- a/src/main/kotlin/es/wokis/di/DataSourceModule.kt
+++ b/src/main/kotlin/es/wokis/di/DataSourceModule.kt
@@ -26,7 +26,7 @@ val dataSourceModule = module {
     single { UserLocalDataSourceImpl(get(named("usersCollection"))) as UserLocalDataSource }
     single { InvoiceLocalDataSourceImpl(get(named("invoicesCollection"))) as InvoiceLocalDataSource }
     single { VerifyLocalDataSourceImpl(get(named("verificationCollection"))) as VerifyLocalDataSource }
-    single { RecoverLocalDataSourceImpl(get(named("verificationCollection"))) as RecoverLocalDataSource }
+    single { RecoverLocalDataSourceImpl(get(named("recoverCollection"))) as RecoverLocalDataSource }
 }
 
 private fun getUsersCollection(database: AppDataBase) = database.usersCollection


### PR DESCRIPTION
Recover password didn't fully worked (or worked at all) because there were some errors on the implementation.

- Fixed collection error
- Fixed filter error
- Removed if statement that didn't really made much sense.